### PR TITLE
Buffer long tasks

### DIFF
--- a/src/lux.js
+++ b/src/lux.js
@@ -54,17 +54,21 @@ LUX = (function () {
   // Note: This code was later added to the LUX snippet. In the snippet we ONLY collect
   //       Long Task entries because that is the only entry type that can not be buffered.
   //       We _copy_ any Long Tasks collected by the snippet and ignore it after that.
-  var gaPerfEntries = "object" === typeof window.LUX_al ? window.LUX_al.slice() : []; // array of Long Tasks (prefer the array from the snippet)
+  var gaSnippetLongTasks = (typeof window.LUX_al === "object") ? window.LUX_al : [];
+  var gaPerfEntries = gaSnippetLongTasks.slice(); // array of Long Tasks (prefer the array from the snippet)
   if ("function" === typeof PerformanceObserver) {
     var perfObserver = new PerformanceObserver(function (list) {
       // Keep an array of perf objects to process later.
       list.getEntries().forEach(function (entry) {
-        gaPerfEntries.push(entry);
+        // Only record long tasks that weren't already recorded by the PerformanceObserver in the snippet
+        if (gaSnippetLongTasks.length === 0 || entry.entryType === "longtask" && gaPerfEntries.indexOf(entry) === -1) {
+          gaPerfEntries.push(entry);
+        }
       });
     });
     try {
       if ("function" === typeof PerformanceLongTaskTiming) {
-        perfObserver.observe({ type: "longtask" });
+        perfObserver.observe({ type: "longtask", buffered: true });
       }
       if ("function" === typeof LargestContentfulPaint) {
         perfObserver.observe({ type: "largest-contentful-paint", buffered: true });

--- a/tests/integration/lux-cpu-times.spec.js
+++ b/tests/integration/lux-cpu-times.spec.js
@@ -17,7 +17,7 @@ describe("LUX CPU timing", () => {
     expect(cpuMetrics.x).toEqual(cpuMetrics.s);
   });
 
-  test.skip("detect and report long tasks that occured before the lux.js script", async () => {
+  test("detect and report long tasks that occured before the lux.js script", async () => {
     await navigateTo("http://localhost:3000/no-inline-snippet-with-cpu.html");
     const luxRequests = requestInterceptor.createRequestMatcher("https://lux.speedcurve.com/lux/");
     const beacon = luxRequests.getUrl(0);


### PR DESCRIPTION
This patch enables buffered long task support, which is fully supported in Chromium [after a bugfix](https://twitter.com/Joseph_Wynn/status/1310755139704074240).

Since customers still have the PerformanceObserver in their snippet, this patch works by first fetching the snippet long tasks, then registering a new PerformanceObserver with `{ type: longtask, buffered: true }`. To prevent "doubling up" and reporting long tasks from both observers, PerformanceLongTaskTiming entries that are observed by the new PerformanceObserver are checked against existing PerformanceLongTaskTiming entries from the snippet before being recorded.