### PR TITLE
Added repo as a private NPM package in Github Packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+; Use NPM registry by default
+//registry.npmjs.org/
+
+; GitHub Packages registry for your org's packages
+speedcurve-metrics:registry=https://npm.pkg.github.com/
+//npm.pkg.github.com/:_authToken=${NPM_AUTH_TOKEN}

--- a/README.md
+++ b/README.md
@@ -17,3 +17,18 @@ This repository contains the source code for lux.js, SpeedCurve's real user moni
 5. Copy `dist/lux.min.js` to [`rum-backend/js/lux.min.test.js`](https://github.com/SpeedCurve-Metrics/rum-backend/blob/main/js/lux.min.test.js)
 6. Deploy rum-backend and check that the RUM data coming in from our test/beta accounts looks valid
 7. Copy `dist/lux.min.js` to [`rum-backend/js/lux.min.js`](https://github.com/SpeedCurve-Metrics/rum-backend/blob/main/js/lux.min.js) and follow the documentation in the rum-backend repository to version the new script
+
+## Publishing in GitHub Packages
+
+This repo is used in `speedcurve-app` as an NPM package.
+Package page: [lux.js](https://github.com/SpeedCurve-Metrics/lux.js/packages/1586797) 
+
+To publish a new version to [private GitHub Packages](https://github.com/orgs/SpeedCurve-Metrics/packages):  
+1. Navigate to your local version of the repo e.g. `cd ~/MyProjects/lux.js`
+2. Add environment variable with personal access token from 1Password (search `GitHub Packages NPM personal access token`):
+```
+export NPM_AUTH_TOKEN="%token%"
+```
+3. Run `npm publish` (use username `speedcurve-bot` and token from previous step if it requies login)
+ 
+Read more: [Working with the npm registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry)

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "lux.js",
+  "name": "@speedcurve-metrics/lux.js",
+  "version": "1.0.2",
   "scripts": {
     "build": "npm run rollup",
     "rollup": "rollup -c rollup.config.js",
@@ -37,5 +38,13 @@
   },
   "prettier": {
     "printWidth": 100
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/speedcurve-metrics"
+  },
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com:speedcurve-metrics/lux.js.git",
+    "directory": "@speedcurve-metrics/lux.js"
   }
 }


### PR DESCRIPTION
Publish this repo as a private NPM package to [SpeedCurve's GitHub Packages](https://github.com/orgs/SpeedCurve-Metrics/packages):

Package page: https://github.com/SpeedCurve-Metrics/lux.js/packages/1586797

Had to use semantic versioning in `package.json` or it won't publish it, I just used `1.0.0` but would be nice to reflect the actual `SCRIPT_VERSION` somehow, or maybe switch to semantic versioning permanently?