### PR TITLE
Ensure event targets are Elements

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -1,5 +1,9 @@
-export function hasParentNode(el: HTMLElement): boolean {
-  if (el.parentNode && (el.parentNode as HTMLElement).tagName) {
+type ElementWithParentNode = Element & {
+  parentNode: Element;
+};
+
+export function hasParentNode(el: Element): el is ElementWithParentNode {
+  if (el.parentNode && (el.parentNode as Element).tagName) {
     return true;
   }
 

--- a/src/interaction.ts
+++ b/src/interaction.ts
@@ -14,11 +14,8 @@ type ButtonOrLinkElement = HTMLButtonElement | HTMLLinkElement;
 
 /**
  * Get the interaction attribution name for an element
- *
- * @param {HTMLElement} el
- * @returns string
  */
-export function interactionAttributionForElement(el: HTMLElement): string {
+export function interactionAttributionForElement(el: Element): string {
   // Our first preference is to use the data-sctrack attribute from anywhere in the tree
   const trackId = getClosestScTrackAttribute(el);
 
@@ -45,14 +42,14 @@ export function interactionAttributionForElement(el: HTMLElement): string {
   }
 
   if (hasParentNode(el)) {
-    return interactionAttributionForElement(el.parentNode as HTMLElement);
+    return interactionAttributionForElement(el.parentNode);
   }
 
   // No suitable attribute was found
   return "";
 }
 
-function getClosestScTrackAttribute(el: HTMLElement): string | null {
+function getClosestScTrackAttribute(el: Element): string | null {
   if (el.hasAttribute("data-sctrack")) {
     const trackId = el.getAttribute("data-sctrack")?.trim();
 
@@ -62,7 +59,7 @@ function getClosestScTrackAttribute(el: HTMLElement): string | null {
   }
 
   if (hasParentNode(el)) {
-    return getClosestScTrackAttribute(el.parentNode as HTMLElement);
+    return getClosestScTrackAttribute(el.parentNode);
   }
 
   return null;

--- a/src/lux.ts
+++ b/src/lux.ts
@@ -1598,8 +1598,8 @@ LUX = (function () {
     if (typeof ghIx["k"] === "undefined") {
       ghIx["k"] = Math.round(_now());
 
-      if (e && e.target) {
-        const trackId = interactionAttributionForElement(e.target as HTMLElement);
+      if (e && e.target instanceof Element) {
+        const trackId = interactionAttributionForElement(e.target);
         if (trackId) {
           ghIx["ki"] = trackId;
         }
@@ -1613,15 +1613,14 @@ LUX = (function () {
     if (typeof ghIx["c"] === "undefined") {
       ghIx["c"] = Math.round(_now());
 
-      let target = null;
+      let target: Element | undefined;
       try {
         // Seeing "Permission denied" errors, so do a simple try-catch.
-        if (e && e.target) {
+        if (e && e.target instanceof Element) {
           target = e.target;
         }
       } catch (e) {
         logger.logEvent(LogEvent.EventTargetAccessError);
-        target = null;
       }
 
       if (target) {
@@ -1630,7 +1629,7 @@ LUX = (function () {
           ghIx["cx"] = e.clientX;
           ghIx["cy"] = e.clientY;
         }
-        const trackId = interactionAttributionForElement(e.target as HTMLElement);
+        const trackId = interactionAttributionForElement(target);
         if (trackId) {
           ghIx["ci"] = trackId;
         }

--- a/tests/integration/lux-interaction.spec.ts
+++ b/tests/integration/lux-interaction.spec.ts
@@ -98,4 +98,24 @@ describe("LUX interaction", () => {
 
     expect(fid).toBeGreaterThan(0);
   });
+
+  test("mousedown handler doesn't throw errors when the event target is not an Element", async () => {
+    const luxRequests = requestInterceptor.createRequestMatcher("/beacon/");
+    await navigateTo("/interaction.html");
+    await page.evaluate("window.dispatchEvent(new MouseEvent('mousedown'))");
+    const ixBeacon = luxRequests.getUrl(1);
+    const ixMetrics = parseNestedPairs(ixBeacon.searchParams.get("IX"));
+
+    expect(parseInt(ixMetrics.c)).toBeGreaterThan(0);
+  });
+
+  test("keydown handler doesn't throw errors when the event target is not an Element", async () => {
+    const luxRequests = requestInterceptor.createRequestMatcher("/beacon/");
+    await navigateTo("/interaction.html");
+    await page.evaluate("window.dispatchEvent(new MouseEvent('keydown'))");
+    const ixBeacon = luxRequests.getUrl(1);
+    const ixMetrics = parseNestedPairs(ixBeacon.searchParams.get("IX"));
+
+    expect(parseInt(ixMetrics.k)).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
This fixes a bug where our event handlers pick up events on targets that do not implement the `Element` interface.