### PR TITLE
Add LUX.conversions to allow custom data to be set by URL pattern matching

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,10 @@
+import { UrlPatternMapping } from "./url-matcher";
+
 export interface ConfigObject {
   auto: boolean;
   autoWhenHidden: boolean;
   beaconUrl: string;
+  conversions?: UrlPatternMapping;
   customerid?: string;
   errorBeaconUrl: string;
   jspagelabel?: string;
@@ -14,11 +17,7 @@ export interface ConfigObject {
   samplerate: number;
   sendBeaconOnPageHidden: boolean;
   trackErrors: boolean;
-  pagegroups?: PageGroups;
-}
-
-interface PageGroups {
-  [key: string]: string[];
+  pagegroups?: UrlPatternMapping;
 }
 
 export type UserConfig = Partial<ConfigObject>;
@@ -30,6 +29,7 @@ export function fromObject(obj: UserConfig): ConfigObject {
     auto: autoMode,
     autoWhenHidden: getProperty(obj, "autoWhenHidden", false),
     beaconUrl: getProperty(obj, "beaconUrl", "https://lux.speedcurve.com/lux/"),
+    conversions: getProperty(obj, "conversions", undefined),
     customerid: getProperty(obj, "customerid", undefined),
     errorBeaconUrl: getProperty(obj, "errorBeaconUrl", "https://lux.speedcurve.com/error/"),
     jspagelabel: getProperty(obj, "jspagelabel", undefined),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,3 @@
 export const START_MARK = "LUX_start";
 export const END_MARK = "LUX_end";
+export const BOOLEAN_TRUE = "true";

--- a/src/lux.ts
+++ b/src/lux.ts
@@ -1,6 +1,6 @@
 import { fitUserTimingEntries } from "./beacon";
 import * as Config from "./config";
-import { END_MARK, START_MARK } from "./constants";
+import { BOOLEAN_TRUE, END_MARK, START_MARK } from "./constants";
 import * as CustomData from "./custom-data";
 import { onVisible, isVisible, wasPrerendered } from "./document";
 import Flags, { addFlag } from "./flags";
@@ -23,7 +23,7 @@ import {
 } from "./performance";
 import * as PO from "./performance-observer";
 import scriptStartTime from "./start-marker";
-import { patternMatchesUrl } from "./url-matcher";
+import { getMatchesFromPatternMap } from "./url-matcher";
 
 let LUX = (window.LUX as LuxGlobal) || {};
 let scriptEndTime = scriptStartTime;
@@ -1378,6 +1378,14 @@ LUX = (function () {
       gFlags = addFlag(gFlags, Flags.PageWasPrerendered);
     }
 
+    if (LUX.conversions) {
+      getMatchesFromPatternMap(LUX.conversions, location.hostname, location.pathname).forEach(
+        (conversion) => {
+          LUX.addData(conversion, BOOLEAN_TRUE);
+        }
+      );
+    }
+
     // We want ALL beacons to have ALL the data used for query filters (geo, pagelabel, browser, & customerdata).
     // So we create a base URL that has all the necessary information:
     const baseUrl = _getBeaconUrl(CustomData.getAllCustomData());
@@ -1703,29 +1711,23 @@ LUX = (function () {
   function _getPageLabel() {
     if (LUX.label) {
       gFlags = addFlag(gFlags, Flags.PageLabelFromLabelProp);
-
       return LUX.label;
-    } else if (typeof LUX.pagegroups !== "undefined") {
-      const pagegroups = LUX.pagegroups;
-      let label = "";
-      for (const pagegroup in pagegroups) {
-        const rules = pagegroups[pagegroup];
-        if (Array.isArray(rules)) {
-          rules.every((rule: string) => {
-            if (patternMatchesUrl(rule, document.location.hostname, document.location.pathname)) {
-              label = pagegroup;
-              return false; // stop when first match is found
-            }
-            return true;
-          });
-        }
-        // exits loop when first match is found
-        if (label) {
-          gFlags = addFlag(gFlags, Flags.PageLabelFromPagegroup);
-          return label;
-        }
+    }
+
+    if (typeof LUX.pagegroups !== "undefined") {
+      const label = getMatchesFromPatternMap(
+        LUX.pagegroups,
+        location.hostname,
+        location.pathname,
+        true
+      );
+
+      if (label) {
+        gFlags = addFlag(gFlags, Flags.PageLabelFromPagegroup);
+        return label;
       }
     }
+
     if (typeof LUX.jspagelabel !== "undefined") {
       const evaluateJsPageLabel = Function('"use strict"; return ' + LUX.jspagelabel);
 
@@ -1734,7 +1736,6 @@ LUX = (function () {
 
         if (label) {
           gFlags = addFlag(gFlags, Flags.PageLabelFromGlobalVariable);
-
           return label;
         }
       } catch (e) {
@@ -1744,7 +1745,6 @@ LUX = (function () {
 
     // default to document.title
     gFlags = addFlag(gFlags, Flags.PageLabelFromDocumentTitle);
-
     return document.title;
   }
 

--- a/src/url-matcher.ts
+++ b/src/url-matcher.ts
@@ -1,3 +1,50 @@
+export interface UrlPatternMapping {
+  [key: string]: string[];
+}
+
+export function getMatchesFromPatternMap(
+  patternMap: UrlPatternMapping,
+  hostname: string,
+  pathname: string
+): string[];
+export function getMatchesFromPatternMap(
+  patternMap: UrlPatternMapping,
+  hostname: string,
+  pathname: string,
+  firstOnly: boolean
+): string | undefined;
+export function getMatchesFromPatternMap(
+  patternMap: UrlPatternMapping,
+  hostname: string,
+  pathname: string,
+  firstOnly?: boolean
+): string[] | (string | undefined) {
+  const matches = [];
+
+  for (const key in patternMap) {
+    const patterns = patternMap[key];
+    if (Array.isArray(patterns)) {
+      for (const i in patterns) {
+        const pattern = patterns[i];
+
+        if (patternMatchesUrl(pattern, hostname, pathname)) {
+          if (firstOnly) {
+            return key;
+          }
+
+          matches.push(key);
+        }
+      }
+    }
+  }
+
+  if (firstOnly) {
+    return undefined;
+  }
+
+  return matches;
+}
+
 export function patternMatchesUrl(pattern: string, hostname: string, pathname: string): boolean {
   const regex = createRegExpFromPattern(pattern);
 

--- a/tests/integration/conversion-url-patterns.spec.ts
+++ b/tests/integration/conversion-url-patterns.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "@playwright/test";
+import { BOOLEAN_TRUE } from "../../src/constants";
+import { getSearchParam, parseNestedPairs } from "../helpers/lux";
+import RequestInterceptor from "../request-interceptor";
+
+test.describe("Conversion event URL patterns", () => {
+  const conversionUrlPatterns = {
+    "order-complete": ["/default.html"],
+    "checkout-begin": ["/prerender-*.html"],
+    "marketing-campaign-1": ["localhost/prerender-index.html"],
+    "marketing-campaign-2": ["*host/default.html"],
+  };
+
+  test("custom data is created for each pattern that matches the current URL", async ({ page }) => {
+    const luxRequests = new RequestInterceptor(page).createRequestMatcher("/beacon/");
+    await page.goto(
+      `/default.html?injectScript=LUX.conversions=${JSON.stringify(conversionUrlPatterns)}`,
+      { waitUntil: "networkidle" }
+    );
+    const beacon = luxRequests.getUrl(0)!;
+    const customData = parseNestedPairs(getSearchParam(beacon, "CD"));
+
+    expect(customData["order-complete"]).toEqual(BOOLEAN_TRUE);
+    expect(customData["checkout-begin"]).toBeUndefined();
+    expect(customData["marketing-campaign-1"]).toBeUndefined();
+    expect(customData["marketing-campaign-2"]).toEqual(BOOLEAN_TRUE);
+  });
+
+  test("partial matches work as expected", async ({ page }) => {
+    const luxRequests = new RequestInterceptor(page).createRequestMatcher("/beacon/");
+    await page.goto(
+      `/prerender-page.html?injectScript=LUX.conversions=${JSON.stringify(conversionUrlPatterns)}`,
+      { waitUntil: "networkidle" }
+    );
+    const beacon = luxRequests.getUrl(0)!;
+    const customData = parseNestedPairs(getSearchParam(beacon, "CD"));
+
+    expect(customData["order-complete"]).toBeUndefined();
+    expect(customData["checkout-begin"]).toEqual(BOOLEAN_TRUE);
+    expect(customData["marketing-campaign-1"]).toBeUndefined();
+    expect(customData["marketing-campaign-2"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
This takes the same format as `LUX.pagegroups` only it allows multiple matches.