### PR TITLE
Add LUX.lateUserTiming

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ export interface ConfigObject {
   errorBeaconUrl: string;
   jspagelabel?: string;
   label?: string;
+  lateUserTiming?: Array<string | RegExp>;
   maxBeaconUrlLength: number;
   maxBeaconUTEntries: number;
   maxErrors: number;
@@ -36,6 +37,7 @@ export function fromObject(obj: UserConfig): ConfigObject {
     errorBeaconUrl: getProperty(obj, "errorBeaconUrl", "https://lux.speedcurve.com/error/"),
     jspagelabel: getProperty(obj, "jspagelabel", undefined),
     label: getProperty(obj, "label", undefined),
+    lateUserTiming: getProperty(obj, "lateUserTiming", undefined),
     maxBeaconUrlLength: getProperty(obj, "maxBeaconUrlLength", 8190),
     maxBeaconUTEntries: getProperty(obj, "maxBeaconUTEntries", 20),
     maxErrors: getProperty(obj, "maxErrors", 5),

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -23,6 +23,7 @@ export const LogEvent: Record<string, number> = {
   UserTimingBeaconSent: 24,
   InteractionBeaconSent: 25,
   CustomDataBeaconSent: 26,
+  LateUserTimingBeaconSent: 27,
 
   // Metric information
   NavigationStart: 41,

--- a/src/performance-observer.ts
+++ b/src/performance-observer.ts
@@ -5,6 +5,8 @@ type PerformanceEntryMap = {
   "first-input": PerformanceEventTiming;
   "largest-contentful-paint": LargestContentfulPaint;
   "layout-shift": LayoutShift;
+  mark: PerformanceMark;
+  measure: PerformanceMeasure;
   navigation: PerformanceNavigationTiming;
   paint: PerformancePaintTiming;
 };

--- a/tests/integration/late-user-timing.spec.ts
+++ b/tests/integration/late-user-timing.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "@playwright/test";
+import { getSearchParam, parseUserTiming } from "../helpers/lux";
+import RequestInterceptor from "../request-interceptor";
+
+test.describe("Late user timing", () => {
+  test("late user timing marks and measures are not sent by default", async ({ page }) => {
+    const luxRequests = new RequestInterceptor(page).createRequestMatcher("/beacon/");
+    await page.goto("/user-timing.html");
+    await luxRequests.waitForMatchingRequest();
+    await page.evaluate(() => {
+      performance.mark("late-mark");
+      performance.measure("late-measure");
+    });
+    const beacon = luxRequests.getUrl(0)!;
+    const UT = parseUserTiming(getSearchParam(beacon, "UT"));
+
+    expect(luxRequests.count()).toEqual(1);
+    expect(Object.keys(UT).length).toEqual(3);
+    expect(UT["late-mark"]).toBeUndefined();
+    expect(UT["late-measure"]).toBeUndefined();
+  });
+
+  test("LUX.lateUserTiming controls which user timing can be sent after the main beacon", async ({
+    page,
+  }) => {
+    const luxRequests = new RequestInterceptor(page).createRequestMatcher("/beacon/");
+    page.on("console", (msg) => console.log(msg.text()));
+    await page.goto(
+      `/user-timing.html?injectScript=LUX.lateUserTiming=["late-mark",/^allowed-.*/];`
+    );
+    await luxRequests.waitForMatchingRequest();
+
+    expect(luxRequests.count()).toEqual(1);
+
+    await luxRequests.waitForMatchingRequest(() =>
+      page.evaluate(() => {
+        performance.mark("late-mark");
+        performance.mark("late-mark-2");
+        performance.measure("late-measure");
+        performance.mark("not-allowed-1");
+        performance.measure("allowed-1");
+        performance.mark("allowed-again-wee");
+      })
+    );
+
+    expect(luxRequests.count()).toEqual(2);
+
+    const mainBeacon = luxRequests.getUrl(0)!;
+    const lateBeacon = luxRequests.getUrl(1)!;
+    const mainUT = parseUserTiming(getSearchParam(mainBeacon, "UT"));
+    const lateUT = parseUserTiming(getSearchParam(lateBeacon, "UT"));
+
+    expect(Object.keys(mainUT).length).toEqual(3);
+    expect(Object.keys(lateUT).length).toEqual(3);
+    expect(lateUT["late-mark"].startTime).toBeGreaterThanOrEqual(0);
+    expect(lateUT["allowed-1"].startTime).toBeGreaterThanOrEqual(0);
+    expect(lateUT["allowed-again-wee"].startTime).toBeGreaterThanOrEqual(0);
+    expect(lateUT["late-mark-2"]).toBeUndefined();
+    expect(lateUT["late-measure"]).toBeUndefined();
+    expect(lateUT["not-allowed-1"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
This is an **experimental feature** that would allow lux.js to measure user timing events that occur _after_ the main beacon has been sent.

## How it works

Users of lux.js provide an "allow list" of user timing events that can be sent after the main beacon.

```js
LUX.lateUserTiming = [
  "my-late-mark", // Specify exact mark/measure names
  /^allowed-.+/, // Specify regular expressions to match against mark/measure names
];
```

## Possible enhancements

Right now there is a hard-coded 100 ms wait time before sending a supplementary user timing beacon. This is to ensure user timing events that occur in quick succession are batched into a single beacon request. I don't have any data to back this up but I suspect 100 ms would not be long enough to prevent multiple beacons from being sent. We could expose this wait time as a configurable value.

## Alternative solutions

### Send late user timing before unload

Another solution would be to have a boolean `LUX.lateUserTiming = true` configuration option that enabled all late user timing events to be sent before the page unload event. This would require very little effort from lux.js users, and could even be enabled via the SpeedCurve UI. The biggest drawback is that there are potentially hundreds or thousands of user timing events that occur before the unload event - probably from third parties. This could result in a massive beacon payload, and put extra strain on our beacon pipeline.

A variation of this solution is to keep the "allow list" approach but send the supplementary user timing beacon before unload rather than after a 100 ms timer.

