### PR TITLE
Fix case where customer page modifies Array constructor

### DIFF
--- a/src/url-matcher.ts
+++ b/src/url-matcher.ts
@@ -27,7 +27,7 @@ export function getMatchesFromPatternMap(
       for (const i in patterns) {
         const pattern = patterns[i];
 
-        if (patternMatchesUrl(pattern, hostname, pathname)) {
+        if (typeof pattern === "string" && patternMatchesUrl(pattern, hostname, pathname)) {
           if (firstOnly) {
             return key;
           }


### PR DESCRIPTION
We saw a strange case with a customer called Ritual where the `Array` constructor on some of their pages was modified to add a `_super` key to every array. This `_super` key pointed to a function, which we would then pass to our pattern matching.

<img width="366" alt="Screenshot 2023-07-20 at 10 28 20 AM" src="https://github.com/SpeedCurve-Metrics/lux.js/assets/31634862/ba748edf-db59-4293-80c4-8b65502a4047">

The fix is to check that a pattern is always a string.