### PR TITLE
Prevent the snippet from overwriting existing LUX variables

### DIFF
--- a/src/snippet.ts
+++ b/src/snippet.ts
@@ -10,19 +10,17 @@ import scriptStartTime from "./start-marker";
 // eslint-disable-next-line no-var
 declare var LUX: LuxGlobal;
 
-LUX = {
-  ac: [],
-  addData: (name, value) => LUX.cmd(["addData", name, value]),
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  cmd: (cmd: Command) => LUX.ac!.push(cmd),
-  getDebug: () => [[scriptStartTime, 0, []]],
-  init: () => LUX.cmd(["init"]),
-  mark: _mark,
-  markLoadTime: () => LUX.cmd(["markLoadTime", msSinceNavigationStart()]),
-  measure: _measure,
-  send: () => LUX.cmd(["send"]),
-  ns: scriptStartTime,
-};
+LUX = window.LUX || ({} as LuxGlobal);
+LUX.ac = [];
+LUX.addData = (name, value) => LUX.cmd(["addData", name, value]);
+LUX.cmd = (cmd: Command) => LUX.ac!.push(cmd);
+LUX.getDebug = () => [[scriptStartTime, 0, []]];
+LUX.init = () => LUX.cmd(["init"]);
+LUX.mark = _mark;
+LUX.markLoadTime = () => LUX.cmd(["markLoadTime", msSinceNavigationStart()]);
+LUX.measure = _measure;
+LUX.send = () => LUX.cmd(["send"]);
+LUX.ns = scriptStartTime;
 
 export default LUX;
 

--- a/tests/integration/page-label.spec.ts
+++ b/tests/integration/page-label.spec.ts
@@ -30,6 +30,21 @@ test.describe("LUX page labels in auto mode", () => {
     expect(hasFlag(beacon, Flags.PageLabelFromUrlPattern)).toBe(false);
   });
 
+  test("using a custom label injected before the snippet", async ({ page }) => {
+    const luxRequests = new RequestInterceptor(page).createRequestMatcher("/beacon/");
+    await page.goto(
+      "/default.html?injectBeforeSnippet=LUX=window.LUX||{};LUX.label='Custom Label';",
+    );
+    await luxRequests.waitForMatchingRequest();
+    const beacon = luxRequests.getUrl(0)!;
+
+    expect(beacon.searchParams.get("l")).toEqual("Custom Label");
+    expect(hasFlag(beacon, Flags.PageLabelFromLabelProp)).toBe(true);
+    expect(hasFlag(beacon, Flags.PageLabelFromDocumentTitle)).toBe(false);
+    expect(hasFlag(beacon, Flags.PageLabelFromGlobalVariable)).toBe(false);
+    expect(hasFlag(beacon, Flags.PageLabelFromUrlPattern)).toBe(false);
+  });
+
   test("custom label is null", async ({ page }) => {
     const luxRequests = new RequestInterceptor(page).createRequestMatcher("/beacon/");
     await page.goto("/default.html?injectScript=LUX.label=null;");


### PR DESCRIPTION
Currently the snippet is overwriting any existing `LUX` variables. Our documentation states that you can set `LUX` properties anywhere so long as you ensure the `LUX` object is defined first, e.g.

```js
LUX = window.LUX || {};
LUX.label = "Custom Page Label";
```

However this pattern is not working because the snippet is blindly setting `LUX = { ... }`. This patch ensures the snippet adds to any existing `LUX` objects rather than overwriting them.