### PR TITLE
Don't clear beacon flags on bfcache restore

### DIFF
--- a/src/lux.ts
+++ b/src/lux.ts
@@ -809,7 +809,7 @@ LUX = (function () {
    * Re-initialize lux.js to start a new "page". This is typically called within a SPA at the
    * beginning of a page transition, but is also called internally when the BF cache is restored.
    */
-  function _init(startTime?: number): void {
+  function _init(startTime?: number, clearFlags = true): void {
     // Some customers (incorrectly) call LUX.init on the very first page load of a SPA. This would
     // cause some first-page-only data (like paint metrics) to be lost. To prevent this, we silently
     // bail from this function when we detect an unnecessary LUX.init call.
@@ -849,8 +849,10 @@ LUX = (function () {
     gFirstInputDelay = undefined;
 
     // Clear flags then set the flag that init was called (ie, this is a SPA).
-    gFlags = 0;
-    gFlags = addFlag(gFlags, Flags.InitCalled);
+    if (clearFlags) {
+      gFlags = 0;
+      gFlags = addFlag(gFlags, Flags.InitCalled);
+    }
 
     // Reset the maximum measure timeout
     createMaxMeasureTimeout();
@@ -1909,7 +1911,7 @@ LUX = (function () {
           if (gbLuxSent) {
             // If the beacon was already sent for this page, we start a new page view and mark the
             // load time as the time it took to restore the page.
-            _init(pageRestoreTime);
+            _init(pageRestoreTime, false);
             _markLoadTime();
           }
 

--- a/tests/integration/bf-cache.spec.ts
+++ b/tests/integration/bf-cache.spec.ts
@@ -65,6 +65,11 @@ test.describe("BF cache integration", () => {
     expect(hasFlag(firstBeacon, Flags.PageWasBfCacheRestored)).toBe(false);
     expect(hasFlag(bfcBeacon, Flags.PageWasBfCacheRestored)).toBe(true);
 
+    // This is not a SPA so the InitCalled flag should not be present on either beacon, even though
+    // the bfcache implementation calls init() to initialise a fresh beacon.
+    expect(hasFlag(firstBeacon, Flags.InitCalled)).toBe(false);
+    expect(hasFlag(bfcBeacon, Flags.InitCalled)).toBe(false);
+
     // Test the page stats are correct for both beacons
     Shared.testPageStats({ beacon: firstBeacon, page, browserName }, true);
     Shared.testPageStats({ beacon: bfcBeacon, page, browserName }, true);


### PR DESCRIPTION
@crockercliff found some data with significant overlap between bfcache restores and soft navs. This helped uncover a bug where we calling `_init()` on bfcache restore is clearing all beacon flags and setting the `InitCalled` flag which we use to determine soft navs. This PR allows the bfcache restore code to tell `init()` not to clear flags.

![image](https://github.com/SpeedCurve-Metrics/lux.js/assets/31634862/5b75b923-6551-4bb9-a881-a29c24f89e82)