### PR TITLE
Add LUX.cookieDomain to control the session cookie domain

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ export interface ConfigObject {
   auto: boolean;
   beaconUrl: string;
   conversions?: UrlPatternMapping;
+  cookieDomain?: string;
   customerid?: string;
   errorBeaconUrl: string;
   jspagelabel?: string;
@@ -34,6 +35,7 @@ export function fromObject(obj: UserConfig): ConfigObject {
     auto: autoMode,
     beaconUrl: getProperty(obj, "beaconUrl", luxOrigin + "/lux/"),
     conversions: getProperty(obj, "conversions"),
+    cookieDomain: getProperty(obj, "cookieDomain"),
     customerid: getProperty(obj, "customerid"),
     errorBeaconUrl: getProperty(obj, "errorBeaconUrl", luxOrigin + "/error/"),
     jspagelabel: getProperty(obj, "jspagelabel"),

--- a/src/lux.ts
+++ b/src/lux.ts
@@ -1844,6 +1844,7 @@ LUX = (function () {
         "=" +
         escape(value) +
         (seconds ? "; max-age=" + seconds : "") +
+        (globalConfig.cookieDomain ? "; domain=" + globalConfig.cookieDomain : "") +
         "; path=/; SameSite=Lax";
     } catch (e) {
       logger.logEvent(LogEvent.CookieSetError);


### PR DESCRIPTION
This would allow user sessions to be tracked across subdomains. For example, setting `LUX.cookieDomain = 'speedcurve.com'` would enable user sessions to be tracked between www.speedcurve.com and app.speedcurve.com, or any other subdomain.