### PR TITLE
Prefer INP entries with a longer processing time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 
+- When duplicate INP entries are encountered, the one with the longest processing time is picked.
 - INP entries are now included in the debug log.
 - The config object is copied before being added to the debug log to reflect the fact that config changes after initialization have no effect.
 - The Debug Parser now shows Core Web Vitals metrics in the beacon details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # lux.js changelog
 
-## 2024-05-09: v315
+## 2024-05-??: v315
+
+### New features
+
+- Add `LUX.interactionBeaconDelay` to control how long lux.js waits before sending the interaction beacon. This defaults to 200ms, but can be increased on pages that have very slow event handlers. Increasing the delay will improve INP collection but may result in data loss if users abandon the page before the beacon is sent.
 
 ### Improvements
 
@@ -8,6 +12,7 @@
 - INP entries are now included in the debug log.
 - The config object is copied before being added to the debug log to reflect the fact that config changes after initialization have no effect.
 - The Debug Parser now shows Core Web Vitals metrics in the beacon details.
+- Interaction beacons have a slightly longer delay before being sent to allow for long INP entries to be picked up.
 
 ## 2024-04-25: v314
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ export interface ConfigObject {
   cookieDomain?: string;
   customerid?: string;
   errorBeaconUrl: string;
+  interactionBeaconDelay: number;
   jspagelabel?: string;
   label?: string;
   maxBeaconUrlLength: number;
@@ -38,6 +39,7 @@ export function fromObject(obj: UserConfig): ConfigObject {
     cookieDomain: getProperty(obj, "cookieDomain"),
     customerid: getProperty(obj, "customerid"),
     errorBeaconUrl: getProperty(obj, "errorBeaconUrl", luxOrigin + "/error/"),
+    interactionBeaconDelay: getProperty(obj, "interactionBeaconDelay", 200),
     jspagelabel: getProperty(obj, "jspagelabel"),
     label: getProperty(obj, "label"),
     maxBeaconUrlLength: getProperty(obj, "maxBeaconUrlLength", 8190),

--- a/src/lux.ts
+++ b/src/lux.ts
@@ -1564,7 +1564,7 @@ LUX = (function () {
 
   function _sendIxAfterDelay(): void {
     clearTimeout(ixTimerId);
-    ixTimerId = setTimeout(_sendIx, 100);
+    ixTimerId = setTimeout(_sendIx, globalConfig.interactionBeaconDelay);
   }
 
   // Beacon back the IX data separately (need to sync with LUX beacon on the backend).

--- a/src/lux.ts
+++ b/src/lux.ts
@@ -1173,7 +1173,7 @@ LUX = (function () {
       details.selector ? "&INPs=" + encodeURIComponent(details.selector) : "",
       "&INPt=" + clamp(floor(details.startTime)),
       "&INPi=" + clamp(floor(details.processingStart - details.startTime)),
-      "&INPp=" + clamp(floor(details.processingEnd - details.processingStart)),
+      "&INPp=" + clamp(floor(details.processingTime)),
       "&INPd=" + clamp(floor(details.startTime + details.duration - details.processingEnd)),
     ].join("");
   }

--- a/src/metric/INP.ts
+++ b/src/metric/INP.ts
@@ -13,6 +13,7 @@ export interface Interaction {
   interactionId: number | undefined;
   duration: number;
   startTime: number;
+  processingTime: number;
   processingStart: number;
   processingEnd: number;
   selector: string | null;
@@ -36,15 +37,14 @@ export function reset(): void {
 export function addEntry(entry: PerformanceEventTiming): void {
   if (entry.interactionId || (entry.entryType === "first-input" && !entryExists(entry))) {
     const { duration, startTime, interactionId, processingStart, processingEnd, target } = entry;
+    const processingTime = processingEnd - processingStart;
     const existingEntry = slowestEntriesMap[interactionId!];
     const selector = target ? getNodeSelector(target) : null;
 
     if (existingEntry) {
-      const existingProcessingTime = existingEntry.processingEnd - existingEntry.processingStart;
-      const newProcessingTime = processingEnd - processingStart;
       const longerDuration = duration > existingEntry.duration;
       const sameWithLongerProcessingTime =
-        duration === existingEntry.duration && newProcessingTime >= existingProcessingTime;
+        duration === existingEntry.duration && processingTime > existingEntry.processingTime;
 
       if (longerDuration || sameWithLongerProcessingTime) {
         // Only replace an existing interation if the duration is longer, or if the duration is the
@@ -54,6 +54,7 @@ export function addEntry(entry: PerformanceEventTiming): void {
         existingEntry.startTime = startTime;
         existingEntry.processingStart = processingStart;
         existingEntry.processingEnd = processingEnd;
+        existingEntry.processingTime = processingTime;
         existingEntry.selector = selector;
       }
     } else {
@@ -64,6 +65,7 @@ export function addEntry(entry: PerformanceEventTiming): void {
         startTime,
         processingStart,
         processingEnd,
+        processingTime,
         selector,
       };
       slowestEntries.push(slowestEntriesMap[interactionId!]);

--- a/src/metric/INP.ts
+++ b/src/metric/INP.ts
@@ -40,7 +40,16 @@ export function addEntry(entry: PerformanceEventTiming): void {
     const selector = target ? getNodeSelector(target) : null;
 
     if (existingEntry) {
-      if (existingEntry.duration < duration) {
+      const existingProcessingTime = existingEntry.processingEnd - existingEntry.processingStart;
+      const newProcessingTime = processingEnd - processingStart;
+      const longerDuration = duration > existingEntry.duration;
+      const sameWithLongerProcessingTime =
+        duration === existingEntry.duration && newProcessingTime >= existingProcessingTime;
+
+      if (longerDuration || sameWithLongerProcessingTime) {
+        // Only replace an existing interation if the duration is longer, or if the duration is the
+        // same but the processing time is longer. The logic around this is that the interaction with
+        // longer processing time is likely to be the event that actually had a handler.
         existingEntry.duration = duration;
         existingEntry.startTime = startTime;
         existingEntry.processingStart = processingStart;

--- a/tests/unit/INP.test.ts
+++ b/tests/unit/INP.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "@jest/globals";
 import * as INP from "../../src/metric/INP";
+import "../../src/window.d.ts";
 
 describe("INP", () => {
   beforeEach(() => {
@@ -12,51 +13,51 @@ describe("INP", () => {
     // Create 50 interactions so that we go over the threshold for using the high percentile value
     while (interactions < 50) {
       interactions++;
-      INP.addEntry(makeEntry(interactions, 100));
+      INP.addEntry(makeEntry({ interactionId: interactions, duration: 100 }));
     }
 
     // Create duplicate event and first-input entries
-    INP.addEntry(makeEntry(60, 300, "event"));
-    INP.addEntry(makeEntry(0, 300, "first-input"));
+    INP.addEntry(makeEntry({ interactionId: 60, duration: 300 }));
+    INP.addEntry(makeEntry({ interationId: 0, duration: 300, entryType: "first-input" }));
 
     // The first-input entry should be ignored, so the high percentile value is one of the first
     // 50 interactions.
     expect(INP.getHighPercentileInteraction()!.duration).toEqual(100);
 
     // Now create a unique first-input entry that becomes the high percentile value
-    INP.addEntry(makeEntry(61, 200, "first-input"));
+    INP.addEntry(makeEntry({ interationId: 61, duration: 200, entryType: "first-input" }));
 
     expect(INP.getHighPercentileInteraction()!.duration).toEqual(200);
   });
 
   test("INP is calculated correctly for small sets of interactions", () => {
-    INP.addEntry(makeEntry(1, 100));
-    INP.addEntry(makeEntry(2, 200));
-    INP.addEntry(makeEntry(3, 300));
-    INP.addEntry(makeEntry(0, 400));
+    INP.addEntry(makeEntry({ interactionId: 1, duration: 100 }));
+    INP.addEntry(makeEntry({ interactionId: 2, duration: 200 }));
+    INP.addEntry(makeEntry({ interactionId: 3, duration: 300 }));
+    INP.addEntry(makeEntry({ interactionId: 0, duration: 400 }));
 
     expect(INP.getHighPercentileInteraction()!.duration).toEqual(300);
   });
 
   test("INP is calculated correctly for small sets of interactions with duplicate IDs", () => {
-    INP.addEntry(makeEntry(1, 100));
-    INP.addEntry(makeEntry(1, 110));
-    INP.addEntry(makeEntry(2, 200));
-    INP.addEntry(makeEntry(3, 300));
-    INP.addEntry(makeEntry(3, 290));
-    INP.addEntry(makeEntry(4, 220));
-    INP.addEntry(makeEntry(4, 200));
-    INP.addEntry(makeEntry(0, 990));
-    INP.addEntry(makeEntry(0, 400));
+    INP.addEntry(makeEntry({ interactionId: 1, duration: 100 }));
+    INP.addEntry(makeEntry({ interactionId: 1, duration: 110 }));
+    INP.addEntry(makeEntry({ interactionId: 2, duration: 200 }));
+    INP.addEntry(makeEntry({ interactionId: 3, duration: 300 }));
+    INP.addEntry(makeEntry({ interactionId: 3, duration: 290 }));
+    INP.addEntry(makeEntry({ interactionId: 4, duration: 220 }));
+    INP.addEntry(makeEntry({ interactionId: 4, duration: 200 }));
+    INP.addEntry(makeEntry({ interactionId: 0, duration: 990 }));
+    INP.addEntry(makeEntry({ interactionId: 0, duration: 400 }));
 
     expect(INP.getHighPercentileInteraction()!.duration).toEqual(300);
   });
 
   test("INP is calculated correctly for large sets of interactions", () => {
     // Generate some long interactions
-    INP.addEntry(makeEntry(1, 600));
-    INP.addEntry(makeEntry(2, 400));
-    INP.addEntry(makeEntry(3, 200));
+    INP.addEntry(makeEntry({ interactionId: 1, duration: 600 }));
+    INP.addEntry(makeEntry({ interactionId: 2, duration: 400 }));
+    INP.addEntry(makeEntry({ interactionId: 3, duration: 200 }));
 
     let interactions = 3;
 
@@ -64,7 +65,7 @@ describe("INP", () => {
     // estimated high percentile value rather than the longest value
     while (interactions < 50) {
       interactions++;
-      INP.addEntry(makeEntry(interactions, 50));
+      INP.addEntry(makeEntry({ interactionId: interactions, duration: 50 }));
     }
 
     expect(INP.getHighPercentileInteraction()!.duration).toEqual(400);
@@ -74,7 +75,7 @@ describe("INP", () => {
     // third-slowest interaction
     while (interactions < 100) {
       interactions++;
-      INP.addEntry(makeEntry(interactions, 50));
+      INP.addEntry(makeEntry({ interactionId: interactions, duration: 50 }));
     }
 
     expect(INP.getHighPercentileInteraction()!.duration).toEqual(200);
@@ -82,15 +83,15 @@ describe("INP", () => {
 
   test("INP is calculated correctly for large sets of interactions with duplicate IDs", () => {
     // Generate some duplicate long interactions
-    INP.addEntry(makeEntry(1, 590));
-    INP.addEntry(makeEntry(1, 600));
-    INP.addEntry(makeEntry(1, 580));
-    INP.addEntry(makeEntry(2, 400));
-    INP.addEntry(makeEntry(2, 399));
-    INP.addEntry(makeEntry(2, 390));
-    INP.addEntry(makeEntry(2, 400));
-    INP.addEntry(makeEntry(3, 200));
-    INP.addEntry(makeEntry(3, 200));
+    INP.addEntry(makeEntry({ interactionId: 1, duration: 590 }));
+    INP.addEntry(makeEntry({ interactionId: 1, duration: 600 }));
+    INP.addEntry(makeEntry({ interactionId: 1, duration: 580 }));
+    INP.addEntry(makeEntry({ interactionId: 2, duration: 400 }));
+    INP.addEntry(makeEntry({ interactionId: 2, duration: 399 }));
+    INP.addEntry(makeEntry({ interactionId: 2, duration: 390 }));
+    INP.addEntry(makeEntry({ interactionId: 2, duration: 400 }));
+    INP.addEntry(makeEntry({ interactionId: 3, duration: 200 }));
+    INP.addEntry(makeEntry({ interactionId: 3, duration: 200 }));
 
     expect(INP.getHighPercentileInteraction()!.duration).toEqual(600);
 
@@ -100,7 +101,7 @@ describe("INP", () => {
     // estimated high percentile value rather than the longest value
     while (interactions < 50) {
       interactions++;
-      INP.addEntry(makeEntry(interactions, 50));
+      INP.addEntry(makeEntry({ interactionId: interactions, duration: 50 }));
     }
 
     expect(INP.getHighPercentileInteraction()!.duration).toEqual(400);
@@ -110,22 +111,33 @@ describe("INP", () => {
     // third-slowest interaction
     while (interactions < 100) {
       interactions++;
-      INP.addEntry(makeEntry(interactions, 50));
+      INP.addEntry(makeEntry({ interactionId: interactions, duration: 50 }));
     }
 
     expect(INP.getHighPercentileInteraction()!.duration).toEqual(200);
   });
+
+  test("Entries with a longer processing time are preferred", () => {
+    const entry1 = makeEntry({ interactionId: 1, duration: 100 });
+    const entry2 = makeEntry({ interactionId: 1, duration: 100 });
+    entry1.processingEnd = 10;
+    entry2.processingEnd = 20;
+
+    INP.addEntry(entry1);
+    INP.addEntry(entry2);
+
+    expect(INP.getHighPercentileInteraction()!.processingEnd).toEqual(20);
+  });
 });
 
-function makeEntry(
-  interactionId: number,
-  duration: number,
-  entryType = "event",
-): PerformanceEventTiming {
+function makeEntry(props: Partial<PerformanceEventTiming>): PerformanceEventTiming {
   return {
-    interactionId,
-    duration,
-    entryType,
+    interactionId: 0,
+    duration: 0,
+    entryType: "event",
     startTime: 0,
+    processingStart: 0,
+    processingEnd: 0,
+    ...props,
   } as PerformanceEventTiming;
 }


### PR DESCRIPTION
We noticed that a large portion of INP events recorded by lux.js had a processing time of zero. This was because Chromium emits multiple interaction events for _all_ events that are triggered, not just events with handlers. Take this code for example:

```html
<button id="btn">Click me!</button>
<script>
document.getElementById("btn").addEventListener("pointerup", doWork);
</script>
```

Assuming that `doWork()` takes 100ms, clicking on this button results in three interaction events, in this order:

- `{ name: "pointerdown", interactionId: 1, duration: 100, processingTime: 0, presentationDelay: 100 }`
- `{ name: "pointerup", interactionId: 1, duration: 100, processingTime: 100, presentationDelay: 0 }`
- `{ name: "click", interactionId: 1, duration: 100, processingTime: 0, presentationDelay: 100 }`

All of the events have the same interation ID and duration, but only the `pointerup` event has any processing time, because that's the event that actually had a handler. Previously lux.js was taking the first event and ignoring subsequent events. This resulted in a correct INP value, but misleading subparts. The presentation delay is _technically correct_ for the `pointerdown` and `click` events, but we might go down a rabbit hole trying to fix the underlying issue because the problem is actually on the `pointerup` handler.

To try and fix the issue, this PR prefers events with a larger processing time. This should increase the likelihood that lux.js reports data for events that actually have handlers.