### PR TITLE
Delivery Type support

### DIFF
--- a/src/lux.ts
+++ b/src/lux.ts
@@ -21,6 +21,7 @@ import {
   timing,
   getEntriesByType,
   navigationType,
+  deliveryType,
   getNavigationEntry,
 } from "./performance";
 import * as PO from "./performance-observer";
@@ -1542,6 +1543,7 @@ LUX = (function () {
       nErrors +
       "nt" +
       navigationType() +
+      deliveryType() +
       (navigator.deviceMemory ? "dm" + round(navigator.deviceMemory) : "") + // device memory (GB)
       (sIx ? "&IX=" + sIx : "") +
       (typeof gFirstInputDelay !== "undefined" ? "&FID=" + gFirstInputDelay : "") +

--- a/src/lux.ts
+++ b/src/lux.ts
@@ -1543,6 +1543,7 @@ LUX = (function () {
       nErrors +
       "nt" +
       navigationType() +
+      "dt" +
       deliveryType() +
       (navigator.deviceMemory ? "dm" + round(navigator.deviceMemory) : "") + // device memory (GB)
       (sIx ? "&IX=" + sIx : "") +

--- a/src/lux.ts
+++ b/src/lux.ts
@@ -1467,6 +1467,7 @@ LUX = (function () {
     const sCPU = cpuTimes();
     const CLS = getCLS();
     const sLuxjs = selfLoading();
+    const dt = deliveryType();
 
     if (!isVisible()) {
       gFlags = addFlag(gFlags, Flags.VisibilityStateNotVisible);
@@ -1505,6 +1506,10 @@ LUX = (function () {
     const is = inlineTagSize("script");
     const ic = inlineTagSize("style");
 
+    // Note some page stat values (the `PS` query string) are non-numeric. To make extracting these
+    // values easier, we append an underscore "_" to the value. Values this is used for include
+    // connection type (ct) and delivery type (dt).
+
     const metricsQueryString =
       // only send Nav Timing and lux.js metrics on initial pageload (not for SPA page views)
       (gbNavSent ? "" : "&NT=" + getNavTiming()) +
@@ -1538,13 +1543,12 @@ LUX = (function () {
       "dw" +
       docWidth(document) +
       (docSize() ? "ds" + docSize() : "") + // document HTTP transfer size (bytes)
-      (connectionType() ? "ct" + connectionType() + "_" : "") + // delimit with "_" since values can be non-numeric so need a way to extract with regex in VCL
+      (connectionType() ? "ct" + connectionType() + "_" : "") +
+      (typeof dt !== "undefined" ? "dt" + dt + "_" : "") + // delivery type
       "er" +
       nErrors +
       "nt" +
       navigationType() +
-      "dt" +
-      deliveryType() +
       (navigator.deviceMemory ? "dm" + round(navigator.deviceMemory) : "") + // device memory (GB)
       (sIx ? "&IX=" + sIx : "") +
       (typeof gFirstInputDelay !== "undefined" ? "&FID=" + gFirstInputDelay : "") +

--- a/src/lux.ts
+++ b/src/lux.ts
@@ -1467,7 +1467,6 @@ LUX = (function () {
     const sCPU = cpuTimes();
     const CLS = getCLS();
     const sLuxjs = selfLoading();
-    const dt = deliveryType();
 
     if (!isVisible()) {
       gFlags = addFlag(gFlags, Flags.VisibilityStateNotVisible);
@@ -1505,6 +1504,9 @@ LUX = (function () {
 
     const is = inlineTagSize("script");
     const ic = inlineTagSize("style");
+    const ds = docSize();
+    const ct = connectionType();
+    const dt = deliveryType();
 
     // Note some page stat values (the `PS` query string) are non-numeric. To make extracting these
     // values easier, we append an underscore "_" to the value. Values this is used for include
@@ -1542,8 +1544,8 @@ LUX = (function () {
       docHeight(document) +
       "dw" +
       docWidth(document) +
-      (docSize() ? "ds" + docSize() : "") + // document HTTP transfer size (bytes)
-      (connectionType() ? "ct" + connectionType() + "_" : "") +
+      (ds ? "ds" + ds : "") + // document HTTP transfer size (bytes)
+      (ct ? "ct" + ct + "_" : "") +
       (typeof dt !== "undefined" ? "dt" + dt + "_" : "") + // delivery type
       "er" +
       nErrors +

--- a/src/performance.ts
+++ b/src/performance.ts
@@ -22,9 +22,23 @@ export function navigationType() {
 
   return "";
 }
-export function deliveryType() {
+
+/**
+ * Returns the delivery type for the current document. To differentiate between the valid empty
+ * string value and browsers that don't support PerformanceResourceTiming.deliveryType, we convert
+ * the empty string value to "(empty string)". Browsers that don't support deliveryType will return
+ * null. Despite straying from the spec, this allows us to differentiate between the two cases.
+ *
+ * @see https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-deliverytype
+ */
+export function deliveryType(): string | undefined {
   const navEntry = getNavigationEntry();
-  return navEntry.deliveryType || "";
+
+  if ("deliveryType" in navEntry) {
+    return navEntry.deliveryType || "(empty string)";
+  }
+
+  return undefined;
 }
 
 type PartialPerformanceNavigationTiming = Partial<PerformanceNavigationTiming> & {

--- a/src/performance.ts
+++ b/src/performance.ts
@@ -22,6 +22,10 @@ export function navigationType() {
 
   return "";
 }
+export function deliveryType() {
+  const navEntry = getNavigationEntry();
+  return navEntry.deliveryType || "";
+}
 
 type PartialPerformanceNavigationTiming = Partial<PerformanceNavigationTiming> & {
   [key: string]: number | string;

--- a/src/window.d.ts
+++ b/src/window.d.ts
@@ -31,7 +31,8 @@ declare global {
   }
 
   interface PerformanceNavigationTiming {
-    activationStart: number;
+    activationStart?: number;
+    deliveryType?: string;
   }
 
   /**

--- a/tests/helpers/shared-tests.ts
+++ b/tests/helpers/shared-tests.ts
@@ -49,10 +49,17 @@ export function testPageStats({ page, browserName, beacon }: SharedTestArgs, has
   // Connection type
   const ct = getSearchParam(beacon, "PS")?.match(/ct([^_]+)/) || [];
 
+  // Delivery type
+  const dt = getSearchParam(beacon, "PS")?.match(/dt([^_]+)/);
+
   if (browserName === "chromium") {
     expect(ct[1]).toEqual("4G");
+    expect(dt![1]).toEqual("(empty string)");
+    expect(getPageStat(beacon, "dm")).toBeGreaterThan(0);
   } else {
     expect(ct.length).toEqual(0);
+    expect(dt).toBeNull();
+    expect(getPageStat(beacon, "dm")).toBeNull();
   }
 
   // No errors
@@ -60,13 +67,6 @@ export function testPageStats({ page, browserName, beacon }: SharedTestArgs, has
 
   // "Normal" navigation type
   expect(getPageStat(beacon, "nt")).toEqual(0);
-
-  // Device memory
-  if (browserName === "chromium") {
-    expect(getPageStat(beacon, "dm")).toBeGreaterThan(0);
-  } else {
-    expect(getPageStat(beacon, "dm")).toBeNull();
-  }
 }
 
 export function testNavigationTiming({ browserName, beacon }: SharedTestArgs) {


### PR DESCRIPTION
This adds the `deliveryType` value from the navigation entry (https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/deliveryType).

There are two possible values at the moment (other than an empty string):

- `cache` to indicate the page was cached
- `navigational-prefetch` to indicate the page was prefetched successfully using speculation rules