### PR TITLE
Prevent custom data from being set to `null` 

### DIFF
--- a/src/custom-data.ts
+++ b/src/custom-data.ts
@@ -5,8 +5,9 @@ let updatedCustomData: CustomDataDict = {};
 
 export function addCustomDataValue(name: string, value: unknown): void {
   const typeV = typeof value;
+  const valueIsEmpty = typeV === "undefined" || value === null;
 
-  if (customDataValues[name] !== value) {
+  if (!valueIsEmpty && customDataValues[name] !== value) {
     // If the value is new or different to the previous value, record it so that later we can send
     // only the values that have changed.
     updatedCustomData[name] = value;
@@ -16,7 +17,7 @@ export function addCustomDataValue(name: string, value: unknown): void {
     customDataValues[name] = value;
   }
 
-  if (typeV === "undefined" || value === null) {
+  if (valueIsEmpty) {
     delete customDataValues[name];
   }
 }

--- a/tests/integration/custom-data.spec.ts
+++ b/tests/integration/custom-data.spec.ts
@@ -120,14 +120,16 @@ test.describe("LUX custom data", () => {
       page.evaluate(() => {
         LUX.addData("var1", "hello");
         LUX.addData("var2", "world");
+        LUX.addData("var3", "and others");
         LUX.send();
       }),
     );
 
-    // Custom data baecon 1
+    // Custom data beacon 1
     await luxRequests.waitForMatchingRequest(() =>
       page.evaluate(() => {
         LUX.addData("var2", "doggo");
+        LUX.addData("var3", null);
       }),
     );
 
@@ -163,7 +165,7 @@ test.describe("LUX custom data", () => {
 
     expect(mainBeacon1Data["var1"]).toEqual("hello");
     expect(mainBeacon1Data["var2"]).toEqual("world");
-    expect(mainBeacon1Data["var3"]).toBeUndefined();
+    expect(mainBeacon1Data["var3"]).toEqual("and others");
 
     expect(cdBeacon1Data["var1"]).toBeUndefined();
     expect(cdBeacon1Data["var2"]).toEqual("doggo");


### PR DESCRIPTION
This bug occurs when a previous non-null value exists.