### PR TITLE
Limit the number of CLS sources to 50

### DIFF
--- a/src/dom.ts
+++ b/src/dom.ts
@@ -15,6 +15,10 @@ export function hasParentNode(el: Element): el is ElementWithParentNode {
 const MAX_SELECTOR_LENGTH = 100;
 
 export function getNodeSelector(node: Node, selector = ""): string {
+  return _getNodeSelector(node, selector).slice(0, MAX_SELECTOR_LENGTH);
+}
+
+function _getNodeSelector(node: Node, selector = ""): string {
   try {
     if (
       selector &&

--- a/src/metric/CLS.ts
+++ b/src/metric/CLS.ts
@@ -9,6 +9,8 @@ let sessionAttributions: CLSAttribution[] = [];
 let largestEntry: LayoutShift | undefined;
 let maximumSessionValue = 0;
 
+export const MAX_CLS_SOURCES = 50;
+
 export function processEntry(entry: LayoutShift): void {
   if (!entry.hadRecentInput) {
     const firstEntry = sessionEntries[0];
@@ -64,6 +66,6 @@ export function getData(): BeaconMetricData["cls"] {
           startTime: processTimeMetric(largestEntry.startTime),
         }
       : null,
-    sources: sessionAttributions.length ? sessionAttributions : null,
+    sources: sessionAttributions.length ? sessionAttributions.slice(0, MAX_CLS_SOURCES) : null,
   };
 }

--- a/tests/unit/CLS.test.ts
+++ b/tests/unit/CLS.test.ts
@@ -29,6 +29,17 @@ describe("CLS", () => {
     // Score didn't change because the biggest window was still the previous window
     expect(CLS.getData().value).toBeCloseTo(1.1);
   });
+
+  test("The number of sources is limited", () => {
+    const entry1 = makeEntry(100, 0.1);
+    entry1.sources = new Array(CLS.MAX_CLS_SOURCES * 1.2).fill({
+      node: document.createElement("div"),
+    });
+
+    CLS.processEntry(entry1);
+
+    expect(CLS.getData().sources).toHaveLength(CLS.MAX_CLS_SOURCES);
+  });
 });
 
 function makeEntry(startTime: number, value: number, hadRecentInput = false): LayoutShift {

--- a/tests/unit/dom.test.ts
+++ b/tests/unit/dom.test.ts
@@ -156,4 +156,20 @@ describe("DOM", () => {
     const buttonSelector = DOM.getNodeSelector(button);
     expect(buttonSelector).toEqual("button.btn.btn-primary");
   });
+
+  test(".getNodeSelector() when the node's ID is very long", () => {
+    const longId = "aBcDeFgHiJkLmNoPqRsTuVwXyZ".repeat(100);
+
+    document.body.innerHTML = `
+      <div class="body-wrapper-y4195VjkmAgT5ZVvGD0Q">
+        <div class="container">
+          <button id="${longId}" class="btn btn-primary">Click me</button>
+        </div>
+      </div>
+    `;
+
+    const button = document.querySelector("button")!;
+    const buttonSelector = DOM.getNodeSelector(button);
+    expect(buttonSelector).toEqual("#" + longId.slice(0, 99));
+  });
 });


### PR DESCRIPTION
99.3% of all beacons have fewer than 50 CLS sources. This cutoff prevents us from sending unnecessarily large beacons and storing data that will likely never be read.

This PR also fixes a small number of cases where element selectors are generated with >100 characters.