### PR TITLE
Fix bug with unload handler firing too late

### DIFF
--- a/src/lux.ts
+++ b/src/lux.ts
@@ -1445,8 +1445,8 @@ LUX = (function () {
   }
 
   // Beacon back the LUX data.
-  function _sendLux(): void {
-    if (!isVisible() && !globalConfig.trackHiddenPages) {
+  function _sendLux(fromUnload: boolean = false): void {
+    if (!isVisible() && !globalConfig.trackHiddenPages && !fromUnload) {
       logger.logEvent(LogEvent.SendCancelledPageHidden);
       return;
     }
@@ -1784,7 +1784,7 @@ LUX = (function () {
       gFlags = addFlag(gFlags, Flags.BeaconSentFromUnloadHandler);
       beacon.addFlag(Flags.BeaconSentFromUnloadHandler);
       logger.logEvent(LogEvent.UnloadHandlerTriggered);
-      _sendLux();
+      _sendLux(true);
       _sendIx();
       beacon.send();
     };

--- a/tests/integration/post-beacon/lcp.spec.ts
+++ b/tests/integration/post-beacon/lcp.spec.ts
@@ -61,8 +61,12 @@ test.describe("POST beacon LCP", () => {
     const insertTime = beforeInsert - beforeInit;
     const beaconTime = beforeBeacon - beforeInit;
 
-    b = luxRequests.get(2)!.postDataJSON() as BeaconPayload;
-    expect(b.lcp!.value).toBeBetween(insertTime, beaconTime);
-    expect(b.lcp!.attribution!.elementSelector).toEqual("html>body>p>img.new-lcp-image");
+    if (lcpSupported) {
+      b = luxRequests.get(2)!.postDataJSON() as BeaconPayload;
+      expect(b.lcp!.value).toBeBetween(insertTime, beaconTime);
+      expect(b.lcp!.attribution!.elementSelector).toEqual("html>body>p>img.new-lcp-image");
+    } else {
+      expect(b.lcp).toBeUndefined();
+    }
   });
 });

--- a/tests/integration/unload.spec.ts
+++ b/tests/integration/unload.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "@playwright/test";
 import Flags from "../../src/flags";
 import { hasFlag } from "../helpers/lux";
 import RequestInterceptor from "../request-interceptor";
+import { setPageHidden } from "../helpers/browsers";
 
 test.describe("LUX unload behaviour", () => {
   test("not automatically sending a beacon when the user navigates away from a page with LUX.auto = false", async ({
@@ -42,9 +43,7 @@ test.describe("LUX unload behaviour", () => {
     });
     expect(luxRequests.count()).toEqual(0);
 
-    await luxRequests.waitForMatchingRequest(() =>
-      page.evaluate(() => document.dispatchEvent(new Event("pagehide"))),
-    );
+    await luxRequests.waitForMatchingRequest(() => setPageHidden(page, true));
     expect(luxRequests.count()).toEqual(1);
     expect(hasFlag(luxRequests.getUrl(0)!, Flags.BeaconSentFromUnloadHandler))!.toBe(true);
   });


### PR DESCRIPTION
Sometimes the unload handler can fire out of order, and the beacon is not sent.