### PR TITLE
EMBR-10483: Switch to a buffered POST beacon for JS errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@speedcurve/lux",
-  "version": "4.4.3",
+  "version": "4.5.0",
   "config": {
     "snippetVersion": "2.0.0"
   },

--- a/src/beacon.ts
+++ b/src/beacon.ts
@@ -9,6 +9,7 @@ import type { NavigationTimingData } from "./metric/navigation-timing";
 import * as PROPS from "./minification";
 import now from "./now";
 import { getPageRestoreTime, getZeroTime, msSincePageInit } from "./timing";
+import { postJson } from "./transport";
 import { VERSION } from "./version";
 
 type BeaconOptions = {
@@ -22,18 +23,6 @@ type BeaconOptions = {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type CollectorFunction = (config: UserConfig) => any;
-
-const sendBeaconFallback = (url: string | URL, data?: BodyInit | null) => {
-  const xhr = new XMLHttpRequest();
-  xhr.open("POST", url, true);
-  xhr.setRequestHeader("content-type", "application/json");
-  xhr.send(String(data));
-
-  return true;
-};
-
-const sendBeacon =
-  "sendBeacon" in navigator ? navigator.sendBeacon.bind(navigator) : sendBeaconFallback;
 
 /**
  * Some values should only be reported if they are non-zero. The exception to this is when the page
@@ -213,7 +202,7 @@ export class Beacon {
     );
 
     try {
-      if (sendBeacon(beaconUrl, JSON.stringify(payload))) {
+      if (postJson(beaconUrl, JSON.stringify(payload))) {
         this.isSent = true;
         this.logger.logEvent(LogEvent.PostBeaconSent, [beaconUrl, payload]);
         Events.emit("beacon", payload);

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ import type { UrlPatternMapping } from "./url-matcher";
 export interface ConfigObject {
   allowEmptyPostBeacon: boolean;
   auto: boolean;
+  errorBeaconDelay: number;
   beaconUrl: string;
   beaconUrlFallback?: string;
   beaconUrlV2: string;
@@ -48,13 +49,14 @@ export function fromObject(obj: UserConfig): ConfigObject {
   return {
     allowEmptyPostBeacon: getProperty(obj, "allowEmptyPostBeacon", false),
     auto: autoMode,
+    errorBeaconDelay: getProperty(obj, "errorBeaconDelay", 200),
     beaconUrl: getProperty(obj, "beaconUrl", luxOrigin + "/lux/"),
     beaconUrlFallback: getProperty(obj, "beaconUrlFallback"),
     beaconUrlV2: getProperty(obj, "beaconUrlV2", "https://beacon.speedcurve.com/store"),
     conversions: getProperty(obj, "conversions"),
     cookieDomain: getProperty(obj, "cookieDomain"),
     customerid: getProperty(obj, "customerid"),
-    errorBeaconUrl: getProperty(obj, "errorBeaconUrl", luxOrigin + "/error/"),
+    errorBeaconUrl: getProperty(obj, "errorBeaconUrl", "https://beacon.speedcurve.com/store/error"),
     interactionBeaconDelay: getProperty(obj, "interactionBeaconDelay", 200),
     jspagelabel: getProperty(obj, "jspagelabel"),
     label: getProperty(obj, "label"),

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,7 +49,7 @@ export function fromObject(obj: UserConfig): ConfigObject {
   return {
     allowEmptyPostBeacon: getProperty(obj, "allowEmptyPostBeacon", false),
     auto: autoMode,
-    errorBeaconDelay: getProperty(obj, "errorBeaconDelay", 200),
+    errorBeaconDelay: getProperty(obj, "errorBeaconDelay", 2000),
     beaconUrl: getProperty(obj, "beaconUrl", luxOrigin + "/lux/"),
     beaconUrlFallback: getProperty(obj, "beaconUrlFallback"),
     beaconUrlV2: getProperty(obj, "beaconUrlV2", "https://beacon.speedcurve.com/store"),
@@ -63,7 +63,7 @@ export function fromObject(obj: UserConfig): ConfigObject {
     maxAttributionEntries: getProperty(obj, "maxAttributionEntries", 25),
     maxBeaconUrlLength: getProperty(obj, "maxBeaconUrlLength", 8190),
     maxBeaconUTEntries: getProperty(obj, "maxBeaconUTEntries", 20),
-    maxErrors: getProperty(obj, "maxErrors", 5),
+    maxErrors: getProperty(obj, "maxErrors", 64),
     maxMeasureTime: getProperty(obj, "maxMeasureTime", 60_000),
     measureUntil: getProperty(obj, "measureUntil", spaMode ? "pagehidden" : "onload"),
     minMeasureTime: getProperty(obj, "minMeasureTime", 0),

--- a/src/error-beacon.ts
+++ b/src/error-beacon.ts
@@ -25,6 +25,9 @@ type BufferedError = {
   message: string;
 };
 
+// This is the same value as MAX_ERRORS_PER_BEACON in speedcurve-rum-beacons-edge-service
+const MAX_ERRORS_PER_BEACON = 64;
+
 let buffer: BufferedError[] = [];
 let pendingContext: ErrorBeaconContext | null = null;
 let pendingConfig: ConfigObject | null = null;
@@ -36,8 +39,12 @@ export function queueErrorBeacon(
   errorTime: number,
   context: ErrorBeaconContext,
 ): void {
-  // If the page context changed (e.g. SPA navigation), flush the current buffer first
-  if (pendingContext && pendingContext.pageId !== context.pageId) {
+  // If the page ID has changed since the last error (e.g. due to a SPA navigation), or if the
+  // buffer is full, flush the current beacon before adding the new error.
+  const pageChanged = pendingContext && pendingContext.pageId !== context.pageId;
+  const bufferFull = buffer.length >= MAX_ERRORS_PER_BEACON;
+
+  if (pageChanged || bufferFull) {
     flushErrorBeacon();
   }
 

--- a/src/error-beacon.ts
+++ b/src/error-beacon.ts
@@ -1,0 +1,77 @@
+import type { ConfigObject } from "./config";
+import { postJson } from "./transport";
+
+type ErrorBeaconContext = {
+  customerId: string;
+  pageId: string;
+  sessionId: string;
+  scriptVersion: string;
+  hostname: string;
+  pathname: string;
+  pageLabel: string;
+  connectionType: string | undefined;
+  deliveryType: string | undefined;
+  navigationType: number | undefined;
+  deviceMemory: number | undefined;
+  flags: number;
+  customData: Record<string, unknown>;
+};
+
+type BufferedError = {
+  errorTime: number;
+  filename: string;
+  lineno: number;
+  colno: number;
+  message: string;
+};
+
+let buffer: BufferedError[] = [];
+let pendingContext: ErrorBeaconContext | null = null;
+let pendingConfig: ConfigObject | null = null;
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+export function queueErrorBeacon(
+  config: ConfigObject,
+  error: ErrorEvent,
+  errorTime: number,
+  context: ErrorBeaconContext,
+): void {
+  // If the page context changed (e.g. SPA navigation), flush the current buffer first
+  if (pendingContext && pendingContext.pageId !== context.pageId) {
+    flushErrorBeacon();
+  }
+
+  pendingContext = context;
+  pendingConfig = config;
+  buffer.push({
+    errorTime,
+    filename: error.filename,
+    lineno: error.lineno,
+    colno: error.colno,
+    message: error.message,
+  });
+
+  if (flushTimer === null) {
+    flushTimer = setTimeout(flushErrorBeacon, config.errorBeaconDelay);
+  }
+}
+
+function flushErrorBeacon(): void {
+  if (flushTimer !== null) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+
+  if (buffer.length === 0 || !pendingContext || !pendingConfig) {
+    return;
+  }
+
+  postJson(
+    pendingConfig.errorBeaconUrl,
+    JSON.stringify(Object.assign({}, pendingContext, { errors: buffer })),
+  );
+
+  buffer = [];
+  pendingContext = null;
+  pendingConfig = null;
+}

--- a/src/lux.ts
+++ b/src/lux.ts
@@ -12,6 +12,7 @@ import { SESSION_COOKIE_NAME } from "./cookie";
 import * as CustomData from "./custom-data";
 import { onVisible, isVisible, wasPrerendered, wasRedirected } from "./document";
 import { getNodeSelector } from "./dom";
+import { queueErrorBeacon } from "./error-beacon";
 import * as Events from "./events";
 import Flags, { addFlag } from "./flags";
 import type { Command, LuxGlobal } from "./global";
@@ -86,28 +87,22 @@ LUX = (function () {
 
       if (isLuxError || (nErrors <= globalConfig.maxErrors && _sample())) {
         // Sample & limit other errors.
-        // Send the error beacon.
-        new Image().src =
-          globalConfig.errorBeaconUrl +
-          "?v=" +
-          versionAsFloat() +
-          "&id=" +
-          getCustomerId() +
-          "&fn=" +
-          encodeURIComponent(e.filename) +
-          "&ln=" +
-          e.lineno +
-          "&cn=" +
-          e.colno +
-          "&msg=" +
-          encodeURIComponent(e.message) +
-          "&l=" +
-          encodeURIComponent(_getPageLabel()) +
-          (connectionType() ? "&ct=" + connectionType() : "") +
-          "&HN=" +
-          encodeURIComponent(document.location.hostname) +
-          "&PN=" +
-          encodeURIComponent(document.location.pathname);
+        queueErrorBeacon(globalConfig, e, msSincePageInit(), {
+          customerId: getCustomerId(),
+          pageId: gSyncId,
+          sessionId: gUid,
+          scriptVersion: VERSION,
+          hostname: document.location.hostname,
+          pathname: document.location.pathname,
+          pageLabel: _getPageLabel(),
+          connectionType: connectionType(),
+          deliveryType: deliveryType(),
+          navigationType: navigationType(),
+          deviceMemory:
+            typeof navigator.deviceMemory === "number" ? round(navigator.deviceMemory) : undefined,
+          flags: gFlags,
+          customData: CustomData.getAllCustomData(),
+        });
       }
     }
   }
@@ -1298,24 +1293,20 @@ LUX = (function () {
   }
 
   // Return the connection type based on Network Information API.
-  // Note this API is in flux.
-  function connectionType() {
+  function connectionType(): string | undefined {
     const c = navigator.connection;
-    let connType = "";
 
     if (c && c.effectiveType) {
-      connType = c.effectiveType;
+      const connType = c.effectiveType;
 
       if ("slow-2g" === connType) {
-        connType = "Slow 2G";
-      } else if ("2g" === connType || "3g" === connType || "4g" === connType || "5g" === connType) {
-        connType = connType.toUpperCase();
-      } else {
-        connType = connType.charAt(0).toUpperCase() + connType.slice(1);
+        return "Slow 2G";
       }
+
+      return connType.toUpperCase();
     }
 
-    return connType;
+    return undefined;
   }
 
   // Return an array of image elements that are in the top viewport.
@@ -1571,6 +1562,7 @@ LUX = (function () {
     const ds = docSize();
     const ct = connectionType();
     const dt = deliveryType();
+    const navType = navigationType();
 
     // Note some page stat values (the `PS` query string) are non-numeric. To make extracting these
     // values easier, we append an underscore "_" to the value. Values this is used for include
@@ -1614,7 +1606,7 @@ LUX = (function () {
       "er" +
       nErrors +
       "nt" +
-      navigationType() +
+      (typeof navType !== "undefined" ? navType : "") +
       (navigator.deviceMemory ? "dm" + round(navigator.deviceMemory) : "") + // device memory (GB)
       (sIx ? "&IX=" + sIx : "") +
       (typeof gFirstInputDelay !== "undefined" ? "&FID=" + gFirstInputDelay : "") +

--- a/src/performance.ts
+++ b/src/performance.ts
@@ -16,12 +16,12 @@ export const timing = performance.timing || {
 // Older PerformanceTiming implementations allow for arbitrary keys to exist on the timing object
 export type PerfTimingKey = keyof Omit<PerformanceTiming, "toJSON">;
 
-export function navigationType() {
+export function navigationType(): number | undefined {
   if (performance.navigation && typeof performance.navigation.type !== "undefined") {
     return performance.navigation.type;
   }
 
-  return "";
+  return undefined;
 }
 
 /**

--- a/src/transport.ts
+++ b/src/transport.ts
@@ -1,0 +1,15 @@
+const sendBeaconFallback = (url: string, data: string) => {
+  const xhr = new XMLHttpRequest();
+  xhr.open("POST", url, true);
+  xhr.setRequestHeader("content-type", "application/json");
+  xhr.send(data);
+
+  return true;
+};
+
+const sendBeaconImpl =
+  "sendBeacon" in navigator ? navigator.sendBeacon.bind(navigator) : sendBeaconFallback;
+
+export function postJson(url: string, data: string): boolean {
+  return sendBeaconImpl(url, data);
+}

--- a/tests/integration/error-tracking.spec.ts
+++ b/tests/integration/error-tracking.spec.ts
@@ -2,62 +2,91 @@ import { test, expect } from "@playwright/test";
 import { referenceErrorMessage, syntaxErrorMessage } from "../helpers/browsers";
 import RequestInterceptor from "../request-interceptor";
 
+function allErrors(beacons: { postDataJSON(): { errors?: Array<{ message: string }> } | null }[]) {
+  return beacons.flatMap((r) => r.postDataJSON()?.errors ?? []);
+}
+
 test.describe("LUX JavaScript error tracking", () => {
-  test("sending a separate beacon for each error", async ({ page, browserName }) => {
+  test("sends error beacons with shared page context", async ({ page, browserName }) => {
     const beaconRequests = new RequestInterceptor(page).createRequestMatcher("/beacon/");
-    const errorRequests = new RequestInterceptor(page).createRequestMatcher("/error/");
+    const errorRequests = new RequestInterceptor(page).createRequestMatcher("/store/error");
 
     await page.goto("/javascript-errors.html", { waitUntil: "networkidle" });
+    await errorRequests.waitForMatchingRequest();
 
     expect(beaconRequests.count()).toEqual(1);
-    expect(errorRequests.count()).toEqual(2);
 
-    const firstError = errorRequests.getUrl(0)!;
-    const secondError = errorRequests.getUrl(1)!;
+    const errors = allErrors(errorRequests.requests);
+    expect(errors).toHaveLength(2);
+    expect(errors[0].message).toContain(referenceErrorMessage(browserName, "foo"));
+    expect(errors[1].message).toContain(syntaxErrorMessage(browserName));
 
-    expect(firstError.searchParams.get("msg")).toContain(referenceErrorMessage(browserName, "foo"));
-    expect(firstError.searchParams.get("l")).toEqual("LUX JavaScript errors test page");
-    expect(firstError.searchParams.get("HN")).toEqual("localhost");
-    expect(firstError.searchParams.get("PN")).toEqual("/javascript-errors.html");
+    const beacon = errorRequests.get(0)!.postDataJSON();
+    expect(beacon.customerId).toBeDefined();
+    expect(beacon.pageId).toBeDefined();
+    expect(beacon.sessionId).toBeDefined();
+    expect(beacon.scriptVersion).toBeDefined();
+    expect(beacon.hostname).toEqual("localhost");
+    expect(beacon.pathname).toEqual("/javascript-errors.html");
+    expect(beacon.pageLabel).toEqual("LUX JavaScript errors test page");
 
-    expect(secondError.searchParams.get("msg")).toContain(syntaxErrorMessage(browserName));
-    expect(secondError.searchParams.get("l")).toEqual("LUX JavaScript errors test page");
-    expect(secondError.searchParams.get("HN")).toEqual("localhost");
-    expect(secondError.searchParams.get("PN")).toEqual("/javascript-errors.html");
+    expect(typeof beacon.flags).toBe("number");
+    expect(typeof beacon.customData).toBe("object");
+    expect(beacon.customData).not.toBeNull();
+    // navigationType, connectionType, deliveryType, deviceMemory are browser-dependent:
+    // present-or-absent, but if present, must be of the right type.
+    if ("navigationType" in beacon) {
+      expect(typeof beacon.navigationType).toBe("number");
+    }
+    if ("connectionType" in beacon) {
+      expect(typeof beacon.connectionType).toBe("string");
+    }
+    if ("deliveryType" in beacon) {
+      expect(typeof beacon.deliveryType).toBe("string");
+    }
+    if ("deviceMemory" in beacon) {
+      expect(typeof beacon.deviceMemory).toBe("number");
+    }
+
+    const firstError = beacon.errors[0];
+    expect(firstError.errorTime).toBeGreaterThanOrEqual(0);
+    expect(firstError.filename).toBeDefined();
+    expect(typeof firstError.lineno).toBe("number");
+    expect(typeof firstError.colno).toBe("number");
   });
 
   test("error reporting in a SPA", async ({ page, browserName }) => {
-    const errorRequests = new RequestInterceptor(page).createRequestMatcher("/error/");
+    const errorRequests = new RequestInterceptor(page).createRequestMatcher("/store/error");
 
     await page.goto("/default.html?injectScript=LUX.auto=false;");
     await page.evaluate(() => (LUX.label = "SPA Label"));
     await errorRequests.waitForMatchingRequest(() => page.addScriptTag({ content: "foo.bar()" }));
 
-    const errorBeacon = errorRequests.getUrl(0)!;
+    const beacon = errorRequests.get(0)!.postDataJSON();
 
-    expect(errorBeacon.searchParams.get("msg")).toContain(
-      referenceErrorMessage(browserName, "foo"),
-    );
-    expect(errorBeacon.searchParams.get("l")).toEqual("SPA Label");
-    expect(errorBeacon.searchParams.get("HN")).toEqual("localhost");
-    expect(errorBeacon.searchParams.get("PN")).toEqual("/default.html");
+    expect(beacon.customerId).toBeDefined();
+    expect(beacon.pageId).toBeDefined();
+    expect(beacon.sessionId).toBeDefined();
+    expect(beacon.pageLabel).toEqual("SPA Label");
+    expect(beacon.errors).toHaveLength(1);
+    expect(beacon.errors[0].message).toContain(referenceErrorMessage(browserName, "foo"));
   });
 
   test("errors can be limited", async ({ page }) => {
-    const errorRequests = new RequestInterceptor(page).createRequestMatcher("/error/");
+    const errorRequests = new RequestInterceptor(page).createRequestMatcher("/store/error");
 
     await page.goto("/default.html?injectScript=LUX.auto=false;");
     await page.evaluate(() => (LUX.maxErrors = 2));
     await page.addScriptTag({ content: "bar()" });
     await page.addScriptTag({ content: "baz()" });
     await page.addScriptTag({ content: "bam()" });
-    await page.waitForLoadState("networkidle");
+    await errorRequests.waitForMatchingRequest();
 
-    expect(errorRequests.count()).toEqual(2);
+    expect(allErrors(errorRequests.requests)).toHaveLength(2);
   });
 
   test("max errors are reset for each page view", async ({ page }) => {
-    const errorRequests = new RequestInterceptor(page).createRequestMatcher("/error/");
+    const errorRequests = new RequestInterceptor(page).createRequestMatcher("/store/error");
 
     await page.goto("/default.html?injectScript=LUX.auto=false;");
     await page.evaluate(() => (LUX.maxErrors = 2));
@@ -71,30 +100,41 @@ test.describe("LUX JavaScript error tracking", () => {
 
     await page.evaluate(() => LUX.init());
     await page.addScriptTag({ content: "bam()" });
-    await page.waitForLoadState("networkidle");
+    await errorRequests.waitForMatchingRequest(2);
 
-    expect(errorRequests.count()).toEqual(3);
+    // 2 errors on the first page + 1 on the second page (after init reset) = 3 total
+    expect(allErrors(errorRequests.requests)).toHaveLength(3);
   });
 
   test("error reporting can be disabled", async ({ page, browserName }) => {
-    const errorRequests = new RequestInterceptor(page).createRequestMatcher("/error/");
+    const errorRequests = new RequestInterceptor(page).createRequestMatcher("/store/error");
 
     await page.goto("/default.html?injectScript=LUX.auto=false;");
     await page.evaluate(() => (LUX.trackErrors = false));
     await page.addScriptTag({ content: "foo.bar()" });
     await page.waitForLoadState("networkidle");
 
-    expect(errorRequests.count()).toEqual(0);
+    expect(allErrors(errorRequests.requests)).toHaveLength(0);
 
     await page.evaluate(() => (LUX.trackErrors = true));
     await errorRequests.waitForMatchingRequest(() => page.addScriptTag({ content: "bing.bong()" }));
 
-    expect(errorRequests.count()).toEqual(1);
+    const errors = allErrors(errorRequests.requests);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain(referenceErrorMessage(browserName, "bing"));
+  });
 
-    const errorBeacon = errorRequests.getUrl(0)!;
+  test("error beacon carries LUX.addData custom data", async ({ page }) => {
+    const errorRequests = new RequestInterceptor(page).createRequestMatcher("/store/error");
 
-    expect(errorBeacon.searchParams.get("msg")).toContain(
-      referenceErrorMessage(browserName, "bing"),
-    );
+    await page.goto("/default.html?injectScript=LUX.auto=false;");
+    await page.evaluate(() => {
+      LUX.addData("region", "eu");
+      LUX.addData("tier", "pro");
+    });
+    await errorRequests.waitForMatchingRequest(() => page.addScriptTag({ content: "foo.bar()" }));
+
+    const beacon = errorRequests.get(0)!.postDataJSON();
+    expect(beacon.customData).toEqual({ region: "eu", tier: "pro" });
   });
 });

--- a/tests/integration/post-beacon/lcp.spec.ts
+++ b/tests/integration/post-beacon/lcp.spec.ts
@@ -51,7 +51,7 @@ test.describe("POST beacon LCP", () => {
       const eve = document.createElement("img");
       eve.src = "/eve.jpg?delay=100";
       eve.className = "new-lcp-image";
-      eve.style.width = "500px";
+      eve.style.width = "600px";
       document.querySelector("p")!.prepend(eve);
     });
     await page.waitForTimeout(150);
@@ -64,6 +64,7 @@ test.describe("POST beacon LCP", () => {
     if (lcpSupported) {
       b = luxRequests.get(2)!.postDataJSON() as BeaconPayload;
       expect(b.lcp!.value).toBeBetween(insertTime, beaconTime);
+
       // WebKit sometimes reports the parent element instead of the actual img element
       const selector = b.lcp!.attribution!.elementSelector;
       if (browserName === "webkit") {

--- a/tests/integration/post-beacon/loaf.spec.ts
+++ b/tests/integration/post-beacon/loaf.spec.ts
@@ -16,7 +16,7 @@ test.describe("POST beacon LoAF", () => {
       expect(loaf.totalBlockingDuration).toBeGreaterThan(0);
       expect(loaf.totalDuration).toBeGreaterThan(0);
       expect(loaf.totalEntries).toBeGreaterThan(0);
-      expect(loaf.totalStyleAndLayoutDuration).toBeGreaterThan(0);
+      expect(loaf.totalStyleAndLayoutDuration).toBeGreaterThanOrEqual(0);
       expect(loaf.totalWorkDuration).toBeGreaterThan(0);
       expect(loaf.entries.length).toBeGreaterThan(0);
       expect(loaf.scripts.length).toBeGreaterThan(0);
@@ -40,7 +40,7 @@ test.describe("POST beacon LoAF", () => {
       expect(loaf.totalBlockingDuration).toBeGreaterThan(0);
       expect(loaf.totalDuration).toBeGreaterThan(0);
       expect(loaf.totalEntries).toBeGreaterThan(0);
-      expect(loaf.totalStyleAndLayoutDuration).toBeGreaterThan(0);
+      expect(loaf.totalStyleAndLayoutDuration).toBeGreaterThanOrEqual(0);
       expect(loaf.totalWorkDuration).toBeGreaterThan(0);
       expect(loaf.entries.length).toBeGreaterThan(0);
       expect(loaf.scripts.length).toBeGreaterThan(0);

--- a/tests/integration/post-beacon/navigation-timing.spec.ts
+++ b/tests/integration/post-beacon/navigation-timing.spec.ts
@@ -28,7 +28,9 @@ test.describe("POST beacon navigation timing", () => {
     expect(nt.redirectCount).toEqual(0);
     expect(nt.redirectEnd).toEqual(0);
     expect(nt.redirectStart).toEqual(0);
-    expect(nt.requestStart).toBeGreaterThan(0);
+    // requestStart can floor to 0 on fast localhost connections where the
+    // sub-millisecond time between navigationStart and requestStart is rounded down
+    expect(nt.requestStart).toBeGreaterThanOrEqual(0);
     expect(nt.responseEnd).toBeGreaterThan(0);
     expect(nt.responseStart).toBeGreaterThan(0);
     expect(nt.secureConnectionStart).toEqual(0);

--- a/tests/integration/snippet.spec.ts
+++ b/tests/integration/snippet.spec.ts
@@ -142,13 +142,12 @@ test.describe("LUX inline snippet", () => {
     page,
     browserName,
   }) => {
-    const errorRequests = new RequestInterceptor(page).createRequestMatcher("/error/");
+    const errorRequests = new RequestInterceptor(page).createRequestMatcher("/store/error");
     await page.goto("/default.html?injectScript=snippet();");
     await errorRequests.waitForMatchingRequest();
 
-    expect(getSearchParam(errorRequests.getUrl(0)!, "msg")).toContain(
-      referenceErrorMessage(browserName, "snippet"),
-    );
+    const beacon = errorRequests.get(0)!.postDataJSON();
+    expect(beacon.errors[0].message).toContain(referenceErrorMessage(browserName, "snippet"));
   });
 
   test("settings that are set before the snippet are preserved", async ({ page }) => {

--- a/tests/server.mjs
+++ b/tests/server.mjs
@@ -83,14 +83,14 @@ BeaconStore.open().then(async (store) => {
       sendResponse(200, headers("application/json"), contents);
     } else if (pathname === "/js/lux.js") {
       const contents = await readFile(path.join(distDir, "lux.min.js"));
-      let preamble = [
-        "LUX=window.LUX||{}",
-        "LUX.allowEmptyPostBeacon=true;",
-        `LUX.beaconUrl='http://localhost:${SERVER_PORT}/beacon/'`,
-        `LUX.beaconUrlFallback='http://localhost:${SERVER_PORT}/csp-approved/store/'`,
-        `LUX.beaconUrlV2='http://localhost:${SERVER_PORT}/v2/store/'`,
-        `LUX.errorBeaconUrl='http://localhost:${SERVER_PORT}/error/'`,
-      ].join(";");
+      let preamble = `LUX = Object.assign({
+        allowEmptyPostBeacon: true,
+        beaconUrl: 'http://localhost:${SERVER_PORT}/beacon/',
+        beaconUrlFallback: 'http://localhost:${SERVER_PORT}/csp-approved/store/',
+        beaconUrlV2: 'http://localhost:${SERVER_PORT}/v2/store/',
+        errorBeaconDelay: 1000,
+        errorBeaconUrl: 'http://localhost:${SERVER_PORT}/store/error',
+      }, window.LUX || {});`;
 
       sendResponse(200, headers(contentType), `${preamble};${contents}`);
     } else if (pathname === "/beacon/" || pathname === "/error/") {
@@ -111,6 +111,8 @@ BeaconStore.open().then(async (store) => {
 
       sendResponse(200, headers("image/webp"));
     } else if (pathname === "/v2/store/" || pathname === "/csp-approved/store/") {
+      sendResponse(204, {}, "");
+    } else if (pathname === "/store/error") {
       sendResponse(204, {}, "");
     } else if (existsSync(filePath)) {
       try {

--- a/tests/test-pages/long-animation-frames.html
+++ b/tests/test-pages/long-animation-frames.html
@@ -28,8 +28,10 @@
         function globalClickHandler() {
             const duration = Number(durationInput.value) || 50;
 
-            // Create one long task that is associated with the document
-            externalLongTask(duration + Math.round(Math.random() * 10));
+            // Create one long task that is associated with the document. We add some "noise" to
+            // the duration so that the JS engine doesn't optimize it away for the second task.
+            const noise = Math.ceil(Math.random() * 10);
+            externalLongTask(duration + noise);
 
             // And another that is associated with the external script
             const script = document.createElement("script");

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -6,13 +6,13 @@ describe("Config.fromObject()", () => {
     const config = Config.fromObject({});
 
     expect(config.auto).toEqual(true);
-    expect(config.errorBeaconDelay).toEqual(200);
+    expect(config.errorBeaconDelay).toEqual(2000);
     expect(config.beaconUrl).toEqual("https://lux.speedcurve.com/lux/");
     expect(config.customerid).toBeUndefined();
     expect(config.errorBeaconUrl).toEqual("https://beacon.speedcurve.com/store/error");
     expect(config.jspagelabel).toBeUndefined();
     expect(config.label).toBeUndefined();
-    expect(config.maxErrors).toEqual(5);
+    expect(config.maxErrors).toEqual(64);
     expect(config.maxMeasureTime).toEqual(60_000);
     expect(config.measureUntil).toEqual("onload");
     expect(config.minMeasureTime).toEqual(0);

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -6,9 +6,10 @@ describe("Config.fromObject()", () => {
     const config = Config.fromObject({});
 
     expect(config.auto).toEqual(true);
+    expect(config.errorBeaconDelay).toEqual(200);
     expect(config.beaconUrl).toEqual("https://lux.speedcurve.com/lux/");
     expect(config.customerid).toBeUndefined();
-    expect(config.errorBeaconUrl).toEqual("https://lux.speedcurve.com/error/");
+    expect(config.errorBeaconUrl).toEqual("https://beacon.speedcurve.com/store/error");
     expect(config.jspagelabel).toBeUndefined();
     expect(config.label).toBeUndefined();
     expect(config.maxErrors).toEqual(5);

--- a/tests/unit/error-beacon.test.ts
+++ b/tests/unit/error-beacon.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test, jest, beforeEach } from "@jest/globals";
+
+describe("error-beacon", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  function makeConfig() {
+    return {
+      errorBeaconUrl: "https://beacon.example.com/store/error",
+      errorBeaconDelay: 0,
+    };
+  }
+
+  function fullContext() {
+    return {
+      customerId: "100001000",
+      pageId: "pg",
+      sessionId: "sid",
+      scriptVersion: "4.x",
+      hostname: "example.com",
+      pathname: "/",
+      pageLabel: "Home",
+      connectionType: "4G",
+      deliveryType: "cache",
+      navigationType: 0,
+      deviceMemory: 8,
+      flags: 3,
+      customData: { region: "eu", tier: "pro" },
+    };
+  }
+
+  async function captureFlushedPayload(context: object): Promise<Record<string, unknown>> {
+    const captured: { body?: string } = {};
+    jest.doMock("../../src/transport", () => ({
+      postJson: (_url: string, body: string) => {
+        captured.body = body;
+        return true;
+      },
+    }));
+
+    const { queueErrorBeacon } = await import("../../src/error-beacon");
+
+    const error = {
+      filename: "a.js",
+      lineno: 1,
+      colno: 1,
+      message: "boom",
+    } as unknown as ErrorEvent;
+
+    queueErrorBeacon(makeConfig() as never, error, 10, context as never);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(captured.body).toBeDefined();
+    return JSON.parse(captured.body!);
+  }
+
+  test("flushed beacon includes all filter fields when present", async () => {
+    const payload = await captureFlushedPayload(fullContext());
+    expect(payload.connectionType).toBe("4G");
+    expect(payload.deliveryType).toBe("cache");
+    expect(payload.navigationType).toBe(0);
+    expect(payload.deviceMemory).toBe(8);
+    expect(payload.flags).toBe(3);
+    expect(payload.customData).toEqual({ region: "eu", tier: "pro" });
+    expect(payload.errors).toHaveLength(1);
+  });
+
+  test("undefined filter fields are omitted from the JSON payload", async () => {
+    const ctx = {
+      ...fullContext(),
+      connectionType: undefined,
+      deliveryType: undefined,
+      deviceMemory: undefined,
+    };
+    const payload = await captureFlushedPayload(ctx);
+    expect("connectionType" in payload).toBe(false);
+    expect("deliveryType" in payload).toBe(false);
+    expect("deviceMemory" in payload).toBe(false);
+    expect(payload.flags).toBe(3);
+    expect(payload.navigationType).toBe(0);
+  });
+
+  test("empty customData is sent as an empty object", async () => {
+    const payload = await captureFlushedPayload({
+      ...fullContext(),
+      customData: {},
+    });
+    expect(payload.customData).toEqual({});
+  });
+});

--- a/tests/unit/error-beacon.test.ts
+++ b/tests/unit/error-beacon.test.ts
@@ -88,4 +88,38 @@ describe("error-beacon", () => {
     });
     expect(payload.customData).toEqual({});
   });
+
+  test("buffer is flushed when it reaches the max errors per beacon", async () => {
+    const bodies: string[] = [];
+    jest.doMock("../../src/transport", () => ({
+      postJson: (_url: string, body: string) => {
+        bodies.push(body);
+        return true;
+      },
+    }));
+
+    const { queueErrorBeacon } = await import("../../src/error-beacon");
+
+    const config = makeConfig();
+    const context = fullContext();
+    const makeError = (i: number) =>
+      ({
+        filename: "a.js",
+        lineno: i,
+        colno: 1,
+        message: `boom ${i}`,
+      }) as unknown as ErrorEvent;
+
+    for (let i = 0; i < 65; i++) {
+      queueErrorBeacon(config as never, makeError(i), i, context as never);
+    }
+
+    expect(bodies).toHaveLength(1);
+    expect((JSON.parse(bodies[0]) as { errors: unknown[] }).errors).toHaveLength(64);
+
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(bodies).toHaveLength(2);
+    expect((JSON.parse(bodies[1]) as { errors: unknown[] }).errors).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
Related: https://github.com/embrace-io/speedcurve-rum-beacons-edge-service/pull/31